### PR TITLE
feat(Memorize): concise stateful sequence selector etc

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,5 @@
+module github.com/joeycumines/go-behaviortree
+
+go 1.13
+
+require github.com/go-test/deep v1.0.5

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,2 @@
+github.com/go-test/deep v1.0.5 h1:AKODKU3pDH1RzZzm6YZu77YWtEAq6uh1rLIAQlay2qc=
+github.com/go-test/deep v1.0.5/go.mod h1:QV8Hv/iy04NyLBxAdO9njL0iVPN1S4d/A3NVv1V36o8=

--- a/memorize.go
+++ b/memorize.go
@@ -1,0 +1,71 @@
+/*
+   Copyright 2020 Joseph Cumines
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package behaviortree
+
+// Memorize encapsulates a tick, and will cache the first non-running status for each child, per "execution", defined
+// as the period until the first non-running status, of the encapsulated tick, facilitating execution of asynchronous
+// nodes in serial with their siblings, using stateless tick implementations, such as sequence and selector.
+//
+// Sync provides a similar but more flexible mechanism, at the expense of greater complexity, and more cumbersome
+// usage. Sync supports modification of children mid-execution, and may be used to implement complex guarding behavior
+// as children of a single Tick, equivalent to more complex structures using multiple memorized sequence nodes.
+func Memorize(tick Tick) Tick {
+	if tick == nil {
+		return nil
+	}
+	var (
+		started bool
+		nodes   []Node
+	)
+	return func(children []Node) (status Status, err error) {
+		if !started {
+			nodes = copyNodes(children)
+			for i := range nodes {
+				var (
+					child    = nodes[i]
+					override Tick
+				)
+				if child == nil {
+					continue
+				}
+				nodes[i] = func() (Tick, []Node) {
+					tick, nodes := child()
+					if override != nil {
+						return override, nodes
+					}
+					if tick == nil {
+						return nil, nodes
+					}
+					return func(children []Node) (Status, error) {
+						status, err := tick(children)
+						if err != nil || status != Running {
+							override = func(children []Node) (Status, error) { return status, err }
+						}
+						return status, err
+					}, nodes
+				}
+			}
+			started = true
+		}
+		status, err = tick(nodes)
+		if err != nil || status != Running {
+			started = false
+			nodes = nil
+		}
+		return
+	}
+}

--- a/memorize_test.go
+++ b/memorize_test.go
@@ -1,0 +1,147 @@
+/*
+   Copyright 2020 Joseph Cumines
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package behaviortree
+
+import (
+	"errors"
+	"testing"
+)
+
+func TestMemorize_nilTick(t *testing.T) {
+	if v := Memorize(nil); v != nil {
+		t.Error(`expected nil`)
+	}
+}
+
+func TestMemorize_nilChildCases(t *testing.T) {
+	var (
+		i int
+		j int
+		e = errors.New(`some_error`)
+	)
+	_, _ = New(
+		Memorize(func(children []Node) (status Status, err error) {
+			if len(children) != 3 ||
+				children[0] == nil ||
+				children[1] != nil ||
+				children[2] == nil {
+				t.Fatal(children)
+			}
+			{
+				tick, c := children[0]()
+				if tick != nil {
+					t.Error(`expected nil`)
+				}
+				if len(c) != 1 || c[0] == nil {
+					t.Error(c)
+				}
+				if status, err := c[0].Tick(); err != nil || status != Failure {
+					t.Error(status, err)
+				}
+			}
+			for x := 0; x < 10; x++ {
+				tick, c := children[2]()
+				if c != nil {
+					t.Error(c)
+				}
+				status, err := tick(c)
+				if status != Running || err != e {
+					t.Error(status, err)
+				}
+			}
+			i++
+			return
+		}),
+		New(nil, New(Selector)),
+		nil,
+		New(func(children []Node) (status Status, err error) {
+			j++
+			status = Running
+			err = e
+			return
+		}),
+	).Tick()
+	if i != 1 {
+		t.Error(i)
+	}
+	if j != 1 {
+		t.Error(j)
+	}
+}
+
+func TestMemorize_errorResets(t *testing.T) {
+	var (
+		i    int
+		j    int
+		e    error
+		node = New(
+			Memorize(func(children []Node) (Status, error) {
+				// this is just sequence but without normalisation of status to failure on error
+				for _, c := range children {
+					status, err := c.Tick()
+					if status != Success || err != nil {
+						return status, err
+					}
+				}
+				return Success, nil
+			}),
+			New(func([]Node) (Status, error) {
+				i++
+				return Success, nil
+			}),
+			New(func([]Node) (Status, error) {
+				j++
+				return Running, e
+			}),
+		)
+	)
+	if i != 0 || j != 0 {
+		t.Fatal(i, j)
+	}
+	if status, err := node.Tick(); err != nil || status != Running {
+		t.Fatal(status, err)
+	}
+	if i != 1 || j != 1 {
+		t.Fatal(i, j)
+	}
+	if status, err := node.Tick(); err != nil || status != Running {
+		t.Fatal(status, err)
+	}
+	if i != 1 || j != 2 {
+		t.Fatal(i, j)
+	}
+	if status, err := node.Tick(); err != nil || status != Running {
+		t.Fatal(status, err)
+	}
+	if i != 1 || j != 3 {
+		t.Fatal(i, j)
+	}
+	e = errors.New(`some_error`)
+	if status, err := node.Tick(); err != e || status != Running {
+		t.Fatal(status, err)
+	}
+	if i != 1 || j != 4 {
+		t.Fatal(i, j)
+	}
+	e = nil
+	if status, err := node.Tick(); err != nil || status != Running {
+		t.Fatal(status, err)
+	}
+	if i != 2 || j != 5 {
+		t.Fatal(i, j)
+	}
+}

--- a/sync.go
+++ b/sync.go
@@ -19,7 +19,9 @@ package behaviortree
 import "sync"
 
 // Sync will wrap a set of nodes in such a way that their real ticks will only be triggered when either the node
-// being ticked was previously running, or no other nodes are running.
+// being ticked was previously running, or no other nodes are running, synchronising calling their Node and Tick calls.
+//
+// NOTE the Memorize function provides similar functionality, and should be preferred, where both are suitable.
 func Sync(nodes []Node) []Node {
 	if nodes == nil {
 		return nil


### PR DESCRIPTION
Memorize is a stateful tick wrapper, as an alternative to the (admittedly, rather obtuse) Sync implementation, which wraps child nodes directly. Both implementations address the same core problem case; Memorize is simpler and more intuitive, and should be used unless the flexibility provided by Sync is necessary.

Also improves documentation, including a link to the academic paper that this simplified mechanism was modeled after.

Resolves #1