### PR TITLE
feat(printer+callframes+values): debug tooling

### DIFF
--- a/behaviortree_test.go
+++ b/behaviortree_test.go
@@ -31,6 +31,7 @@ func TestNode_Tick_nil(t *testing.T) {
 
 	var tree Node
 
+	//noinspection GoNilness
 	status, err = tree.Tick()
 
 	if status != Failure {
@@ -192,5 +193,71 @@ func TestStatus_Status(t *testing.T) {
 		if actual := testCase.Status.Status(); actual != testCase.Expected {
 			t.Errorf("%s failed: expected behaviortree.Status.Status '%s' != actual '%s'", name, testCase.Status, actual)
 		}
+	}
+}
+
+func genTestNewFrame() *Frame { return New(Sequence).Frame() }
+
+func TestNew_frame(t *testing.T) {
+	var (
+		expected = newFrame(genTestNewFrame)
+		actual   = genTestNewFrame()
+	)
+	if expected == nil || actual == nil || expected.PC == 0 || actual.PC == 0 || expected.PC != expected.Entry || actual.PC == actual.Entry {
+		t.Fatal(expected, actual)
+	}
+	actual.PC = actual.Entry
+	if *expected != *actual {
+		t.Errorf("expected != actual\nEXPECTED: %#v\nACTUAL: %#v", expected, actual)
+	}
+}
+
+func genTestNewNodeFrame() *Frame { return NewNode(Sequence, nil).Frame() }
+
+func TestNewNode_frame(t *testing.T) {
+	var (
+		expected = newFrame(genTestNewNodeFrame)
+		actual   = genTestNewNodeFrame()
+	)
+	if expected == nil || actual == nil || expected.PC == 0 || actual.PC == 0 || expected.PC != expected.Entry || actual.PC == actual.Entry {
+		t.Fatal(expected, actual)
+	}
+	actual.PC = actual.Entry
+	if *expected != *actual {
+		t.Errorf("expected != actual\nEXPECTED: %#v\nACTUAL: %#v", expected, actual)
+	}
+}
+
+func Test_factory_nilFrame(t *testing.T) {
+	if v := New(nil).Value(vkFrame{}); v == nil {
+		t.Error(v)
+	}
+	if v := New(nil).Value(1); v != nil {
+		t.Error(v)
+	}
+	if v := NewNode(nil, nil).Value(vkFrame{}); v == nil {
+		t.Error(v)
+	}
+	if v := NewNode(nil, nil).Value(1); v != nil {
+		t.Error(v)
+	}
+	defer func() func() {
+		old := runtimeCallers
+		runtimeCallers = func(skip int, pc []uintptr) int { return 0 }
+		return func() {
+			runtimeCallers = old
+		}
+	}()()
+	if v := New(nil).Value(vkFrame{}); v != nil {
+		t.Error(v)
+	}
+	if v := New(nil).Value(1); v != nil {
+		t.Error(v)
+	}
+	if v := NewNode(nil, nil).Value(vkFrame{}); v != nil {
+		t.Error(v)
+	}
+	if v := NewNode(nil, nil).Value(1); v != nil {
+		t.Error(v)
 	}
 }

--- a/frame.go
+++ b/frame.go
@@ -1,0 +1,81 @@
+/*
+   Copyright 2020 Joseph Cumines
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package behaviortree
+
+import (
+	"reflect"
+)
+
+type (
+	// Frame is a partial copy of runtime.Frame.
+	//
+	// This packages captures details about the caller of it's New and NewNode functions, embedding them into the
+	// nodes themselves, for tree printing / tracing purposes.
+	Frame struct {
+		// PC is the program counter for the location in this frame.
+		// For a frame that calls another frame, this will be the
+		// program counter of a call instruction. Because of inlining,
+		// multiple frames may have the same PC value, but different
+		// symbolic information.
+		PC uintptr
+		// Function is the package path-qualified function name of
+		// this call frame. If non-empty, this string uniquely
+		// identifies a single function in the program.
+		// This may be the empty string if not known.
+		Function string
+		// File and Line are the file name and line number of the
+		// location in this frame. For non-leaf frames, this will be
+		// the location of a call. These may be the empty string and
+		// zero, respectively, if not known.
+		File string
+		Line int
+		// Entry point program counter for the function; may be zero
+		// if not known.
+		Entry uintptr
+	}
+
+	vkFrame struct{}
+)
+
+// Frame will return the call frame for the caller of New/NewNode, an approximation based on the receiver, or nil.
+//
+// This method uses the Value mechanism and is subject to the same warnings / performance limitations.
+func (n Node) Frame() *Frame {
+	if v, _ := n.Value(vkFrame{}).(*Frame); v != nil {
+		v := *v
+		return &v
+	}
+	return newFrame(n)
+}
+
+// Frame will return an approximation of a call frame based on the receiver, or nil.
+func (t Tick) Frame() *Frame { return newFrame(t) }
+
+func newFrame(v interface{}) (f *Frame) {
+	if v := reflect.ValueOf(v); v.IsValid() && v.Kind() == reflect.Func && !v.IsNil() {
+		p := v.Pointer()
+		if v := runtimeFuncForPC(p); v != nil {
+			f = &Frame{
+				PC:       p,
+				Function: v.Name(),
+				Entry:    v.Entry(),
+			}
+			f.File, f.Line = v.FileLine(f.Entry)
+		}
+	}
+	return
+}

--- a/frame_test.go
+++ b/frame_test.go
@@ -1,0 +1,138 @@
+/*
+   Copyright 2020 Joseph Cumines
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package behaviortree
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestNode_Frame(t *testing.T) {
+	for _, test := range []struct {
+		Name  string
+		Node  Node
+		Frame *Frame
+	}{
+		{
+			Name: `nil`,
+		},
+		{
+			Name: `nn with value`,
+			Node: nn(nil, nil).WithValue(1, 2),
+			Frame: &Frame{
+				Function: `github.com/joeycumines/go-behaviortree.Node.WithValue.func1`,
+				File:     `value.go`,
+			},
+		},
+		{
+			Name: `nn with value explicit frame`,
+			Node: nn(nil, nil).WithValue(vkFrame{}, &Frame{
+				PC:       0x568dc0,
+				Function: "github.com/joeycumines/go-behaviortree.glob..func1.1",
+				File:     "C:/Users/under/go/src/github.com/joeycumines/go-behaviortree/behaviortree.go",
+				Line:     53,
+				Entry:    0x568dc0,
+			}),
+			Frame: &Frame{
+				Function: "github.com/joeycumines/go-behaviortree.glob..func1.1",
+				File:     "behaviortree.go",
+			},
+		},
+	} {
+		t.Run(test.Name, func(t *testing.T) {
+			for i := 0; i < 2; i++ {
+				frame := test.Node.Frame()
+				if frame != nil {
+					if frame.Line == 0 {
+						t.Error(frame.Line)
+					} else {
+						frame.Line = 0
+					}
+					if frame.PC == 0 {
+						t.Error(frame.PC)
+					} else {
+						frame.PC = 0
+					}
+					if frame.Entry == 0 {
+						t.Error(frame.Entry)
+					} else {
+						frame.Entry = 0
+					}
+					if i := strings.LastIndex(frame.File, "/"); i >= 0 {
+						frame.File = frame.File[i+1:]
+					} else {
+						t.Error(frame.File)
+					}
+				}
+				if (frame == nil) != (test.Frame == nil) || (frame != nil && *frame != *test.Frame) {
+					t.Errorf("%+v", frame)
+				}
+			}
+		})
+	}
+}
+
+func TestTick_Frame(t *testing.T) {
+	for _, test := range []struct {
+		Name  string
+		Tick  Tick
+		Frame *Frame
+	}{
+		{
+			Name: `nil`,
+		},
+		{
+			Name: `sequence`,
+			Tick: Sequence,
+			Frame: &Frame{
+				Function: `github.com/joeycumines/go-behaviortree.Sequence`,
+				File:     `sequence.go`,
+			},
+		},
+	} {
+		t.Run(test.Name, func(t *testing.T) {
+			for i := 0; i < 2; i++ {
+				frame := test.Tick.Frame()
+				if frame != nil {
+					if frame.Line == 0 {
+						t.Error(frame.Line)
+					} else {
+						frame.Line = 0
+					}
+					if frame.PC == 0 {
+						t.Error(frame.PC)
+					} else {
+						frame.PC = 0
+					}
+					if frame.Entry == 0 {
+						t.Error(frame.Entry)
+					} else {
+						frame.Entry = 0
+					}
+					if i := strings.LastIndex(frame.File, "/"); i >= 0 {
+						frame.File = frame.File[i+1:]
+					} else {
+						t.Error(frame.File)
+					}
+				}
+				if (frame == nil) != (test.Frame == nil) || (frame != nil && *frame != *test.Frame) {
+					t.Errorf("%+v", frame)
+				}
+			}
+		})
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -2,4 +2,8 @@ module github.com/joeycumines/go-behaviortree
 
 go 1.13
 
-require github.com/go-test/deep v1.0.5
+require (
+	github.com/go-test/deep v1.0.6
+	github.com/stretchr/testify v1.6.1 // indirect
+	github.com/xlab/treeprint v1.0.0
+)

--- a/go.sum
+++ b/go.sum
@@ -1,2 +1,15 @@
-github.com/go-test/deep v1.0.5 h1:AKODKU3pDH1RzZzm6YZu77YWtEAq6uh1rLIAQlay2qc=
-github.com/go-test/deep v1.0.5/go.mod h1:QV8Hv/iy04NyLBxAdO9njL0iVPN1S4d/A3NVv1V36o8=
+github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8=
+github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/go-test/deep v1.0.6 h1:UHSEyLZUwX9Qoi99vVwvewiMC8mM2bf7XEM2nqvzEn8=
+github.com/go-test/deep v1.0.6/go.mod h1:QV8Hv/iy04NyLBxAdO9njL0iVPN1S4d/A3NVv1V36o8=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
+github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
+github.com/stretchr/testify v1.6.1 h1:hDPOHmpOpP40lSULcqw7IrRb/u7w6RpDC9399XyoNd0=
+github.com/stretchr/testify v1.6.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
+github.com/xlab/treeprint v1.0.0 h1:J0TkWtiuYgtdlrkkrDLISYBQ92M+X5m4LrIIMKrbDTs=
+github.com/xlab/treeprint v1.0.0/go.mod h1:IoImgRak9i3zJyuxOKUP1v4UZd1tMoKkq/Cimt1uhCg=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c h1:dUUwHk2QECo/6vqA44rthZ8ie2QXMNeKRTHCNY2nXvo=
+gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/printer.go
+++ b/printer.go
@@ -1,0 +1,219 @@
+/*
+   Copyright 2020 Joseph Cumines
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package behaviortree
+
+import (
+	"bytes"
+	"fmt"
+	"github.com/xlab/treeprint"
+	"io"
+	"strings"
+)
+
+type (
+	// Printer models something providing behavior tree printing capabilities
+	Printer interface {
+		// Fprint writes a representation node to output
+		Fprint(output io.Writer, node Node) error
+	}
+
+	// TreePrinter provides a generalised implementation of Printer used as the DefaultPrinter
+	TreePrinter struct {
+		// Inspector configures the meta and value for a node with a given tick
+		Inspector func(node Node, tick Tick) (meta []interface{}, value interface{})
+		// Formatter initialises a new printer tree and returns it as a TreePrinterNode
+		Formatter func() TreePrinterNode
+	}
+
+	// TreePrinterNode models a BT node for printing and is used by the TreePrinter implementation in this package
+	TreePrinterNode interface {
+		// Add should wire up a new node to the receiver then return it
+		Add(meta []interface{}, value interface{}) TreePrinterNode
+		// Bytes should encode the node and all children in preparation for use within TreePrinter
+		Bytes() []byte
+	}
+)
+
+var (
+	// DefaultPrinter is used to implement Node.String
+	DefaultPrinter Printer = TreePrinter{
+		Inspector: DefaultPrinterInspector,
+		Formatter: DefaultPrinterFormatter,
+	}
+)
+
+// String implements fmt.Stringer using DefaultPrinter
+func (n Node) String() string {
+	var b bytes.Buffer
+	if err := DefaultPrinter.Fprint(&b, n); err != nil {
+		return fmt.Sprintf(`behaviortree.DefaultPrinter error: %s`, err)
+	}
+	return string(b.Bytes())
+}
+
+// DefaultPrinterFormatter is used by DefaultPrinter
+func DefaultPrinterFormatter() TreePrinterNode { return new(treePrinterNodeXlab) }
+
+// DefaultPrinterInspector is used by DefaultPrinter
+func DefaultPrinterInspector(node Node, tick Tick) ([]interface{}, interface{}) {
+	var (
+		nodePtr      uintptr
+		nodeFileLine string
+		nodeName     string
+		tickPtr      uintptr
+		tickFileLine string
+		tickName     string
+	)
+
+	if v := node.Frame(); v != nil {
+		nodePtr = v.PC
+		nodeFileLine = shortFileLine(v.File, v.Line)
+		nodeName = v.Function
+	} else if node == nil {
+		nodeName = `<nil>`
+	}
+	if nodeFileLine == `` {
+		nodeFileLine = `-`
+	}
+	if nodeName == `` {
+		nodeName = `-`
+	}
+
+	if v := tick.Frame(); v != nil {
+		tickPtr = v.PC
+		tickFileLine = shortFileLine(v.File, v.Line)
+		tickName = v.Function
+	} else if tick == nil {
+		tickName = `<nil>`
+	}
+	if tickFileLine == `` {
+		tickFileLine = `-`
+	}
+	if tickName == `` {
+		tickName = `-`
+	}
+
+	return []interface{}{
+		fmt.Sprintf(`%#x`, nodePtr),
+		nodeFileLine,
+		fmt.Sprintf(`%#x`, tickPtr),
+		tickFileLine,
+	}, fmt.Sprintf(`%s | %s`, nodeName, tickName)
+}
+
+// Fprint implements Printer.Fprint
+func (p TreePrinter) Fprint(output io.Writer, node Node) error {
+	tree := p.Formatter()
+	p.build(tree, node)
+	if _, err := io.Copy(output, bytes.NewReader(tree.Bytes())); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (p TreePrinter) build(tree TreePrinterNode, node Node) {
+	if node != nil {
+		tick, children := node()
+		tree = tree.Add(p.Inspector(node, tick))
+		for _, child := range children {
+			p.build(tree, child)
+		}
+	}
+}
+
+func shortFileLine(f string, l int) string {
+	if i := strings.LastIndex(f, "/"); i >= 0 {
+		f = f[i+1:]
+	}
+	return fmt.Sprintf(`%s:%d`, f, l)
+}
+
+type (
+	treePrinterNodeXlab struct {
+		node    treeprint.Tree
+		sizes   []int
+		updates []func()
+	}
+	treePrinterNodeXlabMeta struct {
+		*treePrinterNodeXlab
+		interfaces []interface{}
+		strings    []string
+	}
+)
+
+func (n *treePrinterNodeXlab) Add(meta []interface{}, value interface{}) TreePrinterNode {
+	if n.node == nil {
+		r := new(treePrinterNodeXlab)
+		m := &treePrinterNodeXlabMeta{treePrinterNodeXlab: r, interfaces: meta}
+		m.updates = append(m.updates, m.update)
+		n.node = treeprint.New()
+		n.node.SetMetaValue(m)
+		n.node.SetValue(value)
+		return n
+	}
+	m := &treePrinterNodeXlabMeta{treePrinterNodeXlab: n, interfaces: meta}
+	m.updates = append(m.updates, m.update)
+	return &treePrinterNodeXlab{node: n.node.AddMetaBranch(m, value)}
+}
+func (n *treePrinterNodeXlab) Bytes() []byte {
+	if n := n.node; n != nil {
+		b := n.Bytes()
+		if l := len(b); l != 0 && b[l-1] == '\n' {
+			b = b[:l-1]
+		}
+		return b
+	}
+	return []byte(`<nil>`)
+}
+func (m *treePrinterNodeXlabMeta) String() string {
+	const space = ' '
+	for _, update := range m.updates {
+		update()
+	}
+	m.updates = nil
+	if m.interfaces != nil {
+		panic(fmt.Errorf(`m.interfaces %v should be nil`, m.interfaces))
+	}
+	if len(m.sizes) < len(m.strings) {
+		panic(fmt.Errorf(`m.sizes %v mismatched m.strings %v`, m.sizes, m.strings))
+	}
+	var b []byte
+	for i, size := range m.sizes {
+		if i != 0 {
+			b = append(b, space)
+		}
+		if i < len(m.strings) {
+			b = append(b, m.strings[i]...)
+			size -= len(m.strings[i])
+		}
+		b = append(b, bytes.Repeat([]byte{space}, size)...)
+	}
+	return string(b)
+}
+func (m *treePrinterNodeXlabMeta) update() {
+	m.strings = make([]string, len(m.interfaces))
+	for i, v := range m.interfaces {
+		m.strings[i] = fmt.Sprint(v)
+		if i == len(m.sizes) {
+			m.sizes = append(m.sizes, 0)
+		}
+		if v := len(m.strings[i]); v > m.sizes[i] {
+			m.sizes[i] = v
+		}
+	}
+	m.interfaces = nil
+}

--- a/printer_test.go
+++ b/printer_test.go
@@ -1,0 +1,245 @@
+/*
+   Copyright 2020 Joseph Cumines
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package behaviortree
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"github.com/go-test/deep"
+	"io"
+	"regexp"
+	"runtime"
+	"strings"
+	"testing"
+)
+
+func replacePointers(b string) string {
+	var (
+		m = make(map[string]struct{})
+		r []string
+		n int
+	)
+	for _, v := range regexp.MustCompile(`(?:[[:^alnum:]]|^)(0x[[:alnum:]]{1,16})(?:[[:^alnum:]]|$)`).FindAllStringSubmatch(b, -1) {
+		if v := v[1]; v != `0x0` {
+			if _, ok := m[v]; !ok {
+				n++
+				m[v] = struct{}{}
+				r = append(r, v, fmt.Sprintf(`%#x`, n))
+			}
+		}
+	}
+	return strings.NewReplacer(r...).Replace(b)
+}
+
+func TestNode_String(t *testing.T) {
+	for _, testCase := range []struct {
+		Name  string
+		Node  Node
+		Value string
+	}{
+		{
+			Name:  `nil node`,
+			Node:  nil,
+			Value: `<nil>`,
+		},
+		{
+			Name:  `single sequence`,
+			Node:  New(Sequence),
+			Value: "[0x1 printer_test.go:62 0x2 sequence.go:21]  github.com/joeycumines/go-behaviortree.TestNode_String | github.com/joeycumines/go-behaviortree.Sequence",
+		},
+		{
+			Name:  `single closure`,
+			Node:  New(func(children []Node) (Status, error) { panic(`TestNode_String`) }),
+			Value: "[0x1 printer_test.go:67 0x2 printer_test.go:67]  github.com/joeycumines/go-behaviortree.TestNode_String | github.com/joeycumines/go-behaviortree.TestNode_String.func1",
+		},
+		{
+			Name:  `nil tick`,
+			Node:  New(nil),
+			Value: "[0x1 printer_test.go:72 0x0 -]  github.com/joeycumines/go-behaviortree.TestNode_String | <nil>",
+		},
+		{
+			Name:  `example counter`,
+			Node:  newExampleCounter(),
+			Value: "[0x1 example_test.go:47 0x2 selector.go:21]  github.com/joeycumines/go-behaviortree.newExampleCounter | github.com/joeycumines/go-behaviortree.Selector\n├── [0x3 example_test.go:49 0x4 sequence.go:21]  github.com/joeycumines/go-behaviortree.newExampleCounter | github.com/joeycumines/go-behaviortree.Sequence\n│\u00a0\u00a0 ├── [0x5 example_test.go:51 0x6 example_test.go:52]  github.com/joeycumines/go-behaviortree.newExampleCounter | github.com/joeycumines/go-behaviortree.newExampleCounter.func3\n│\u00a0\u00a0 ├── [0x7 example_test.go:40 0x8 example_test.go:41]  github.com/joeycumines/go-behaviortree.newExampleCounter | github.com/joeycumines/go-behaviortree.newExampleCounter.func2\n│\u00a0\u00a0 └── [0x9 example_test.go:32 0xa example_test.go:33]  github.com/joeycumines/go-behaviortree.newExampleCounter.func1 | github.com/joeycumines/go-behaviortree.newExampleCounter.func1.1\n└── [0xb example_test.go:62 0x4 sequence.go:21]  github.com/joeycumines/go-behaviortree.newExampleCounter | github.com/joeycumines/go-behaviortree.Sequence\n    ├── [0xc example_test.go:64 0xd example_test.go:65]  github.com/joeycumines/go-behaviortree.newExampleCounter | github.com/joeycumines/go-behaviortree.newExampleCounter.func4\n    ├── [0x7 example_test.go:40 0x8 example_test.go:41]  github.com/joeycumines/go-behaviortree.newExampleCounter | github.com/joeycumines/go-behaviortree.newExampleCounter.func2\n    └── [0x9 example_test.go:32 0xa example_test.go:33]  github.com/joeycumines/go-behaviortree.newExampleCounter.func1 | github.com/joeycumines/go-behaviortree.newExampleCounter.func1.1",
+		},
+	} {
+		t.Run(testCase.Name, func(t *testing.T) {
+			value := testCase.Node.String()
+			//t.Logf("\n---\n%s\n---", value)
+			value = replacePointers(value)
+			if value != testCase.Value {
+				t.Errorf("unexpected value: %q\n> %s", value, strings.ReplaceAll(value, "\n", "\n> "))
+			}
+		})
+	}
+}
+
+type mockPrinter struct {
+	fprint func(output io.Writer, node Node) error
+}
+
+func (m *mockPrinter) Fprint(output io.Writer, node Node) error { return m.fprint(output, node) }
+
+func TestNode_String_error(t *testing.T) {
+	defer func() func() {
+		old := DefaultPrinter
+		DefaultPrinter = &mockPrinter{fprint: func(output io.Writer, node Node) error {
+			return errors.New(`some_error`)
+		}}
+		return func() {
+			DefaultPrinter = old
+		}
+	}()()
+	if v := Node(nil).String(); v != `behaviortree.DefaultPrinter error: some_error` {
+		t.Error(v)
+	}
+}
+
+func TestTreePrinter_Fprint_copyError(t *testing.T) {
+	r, w := io.Pipe()
+	_ = r.Close()
+	if err := (TreePrinter{Formatter: DefaultPrinterFormatter, Inspector: DefaultPrinterInspector}).Fprint(w, Node(nil)); err != io.ErrClosedPipe {
+		t.Error(err)
+	}
+}
+
+func Test_treePrinterNodeXlabMeta_String_panicLen(t *testing.T) {
+	defer func() {
+		if r := fmt.Sprint(recover()); r != `m.sizes [4] mismatched m.strings [one two]` {
+			t.Error(r)
+		}
+	}()
+	m := &treePrinterNodeXlabMeta{
+		treePrinterNodeXlab: &treePrinterNodeXlab{
+			sizes: []int{4},
+		},
+		strings: []string{`one`, `two`},
+	}
+	_ = m.String()
+	t.Error(`expected panic`)
+}
+
+func Test_treePrinterNodeXlabMeta_String_panicInterfaces(t *testing.T) {
+	defer func() {
+		if r := fmt.Sprint(recover()); r != `m.interfaces [] should be nil` {
+			t.Error(r)
+		}
+	}()
+	m := &treePrinterNodeXlabMeta{
+		treePrinterNodeXlab: &treePrinterNodeXlab{
+			sizes: []int{4},
+		},
+		strings:    []string{`one`, `two`},
+		interfaces: make([]interface{}, 0),
+	}
+	_ = m.String()
+	t.Error(`expected panic`)
+}
+
+func dummyNode() (Tick, []Node) {
+	return nil, nil
+}
+
+func TestDefaultPrinterInspector_nil(t *testing.T) {
+	var actual [2]interface{}
+	actual[0], actual[1] = DefaultPrinterInspector(nil, nil)
+	if diff := deep.Equal(
+		actual,
+		[2]interface{}{
+			[]interface{}{
+				`0x0`,
+				`-`,
+				`0x0`,
+				`-`,
+			},
+			`<nil> | <nil>`,
+		},
+	); diff != nil {
+		t.Errorf("unexpected diff:\n%s", strings.Join(diff, "\n"))
+	}
+	var node Node = dummyNode
+	actual[0], actual[1] = DefaultPrinterInspector(node, nil)
+	if diff := deep.Equal(
+		actual,
+		[2]interface{}{
+			[]interface{}{
+				fmt.Sprintf(`%p`, node),
+				`printer_test.go:155`,
+				`0x0`,
+				`-`,
+			},
+			`github.com/joeycumines/go-behaviortree.dummyNode | <nil>`,
+		},
+	); diff != nil {
+		t.Errorf("unexpected diff:\n%s", strings.Join(diff, "\n"))
+	}
+	tick := Selector
+	actual[0], actual[1] = DefaultPrinterInspector(nil, tick)
+	if diff := deep.Equal(
+		actual,
+		[2]interface{}{
+			[]interface{}{
+				`0x0`,
+				`-`,
+				fmt.Sprintf(`%p`, tick),
+				`selector.go:21`,
+			},
+			`<nil> | github.com/joeycumines/go-behaviortree.Selector`,
+		},
+	); diff != nil {
+		t.Errorf("unexpected diff:\n%s", strings.Join(diff, "\n"))
+	}
+}
+
+func TestDefaultPrinterInspector_noName(t *testing.T) {
+	defer func() func() {
+		old := runtimeFuncForPC
+		runtimeFuncForPC = func(pc uintptr) *runtime.Func { return nil }
+		return func() {
+			runtimeFuncForPC = old
+		}
+	}()()
+	var actual [2]interface{}
+	actual[0], actual[1] = DefaultPrinterInspector(dummyNode, Sequence)
+	if diff := deep.Equal(
+		actual,
+		[2]interface{}{
+			[]interface{}{
+				`0x0`,
+				`-`,
+				`0x0`,
+				`-`,
+			},
+			`- | -`,
+		},
+	); diff != nil {
+		t.Errorf("unexpected diff:\n%s", strings.Join(diff, "\n"))
+	}
+}
+
+func TestTreePrinter_Fprint_emptyMeta(t *testing.T) {
+	p := TreePrinter{
+		Inspector: func(node Node, tick Tick) (meta []interface{}, value interface{}) { return []interface{}{``, ``, ``}, `` },
+		Formatter: DefaultPrinterFormatter,
+	}
+	b := new(bytes.Buffer)
+	_ = p.Fprint(b, nn(nil))
+	if v := string(b.Bytes()); v != `[  ]  ` {
+		t.Error(v)
+	}
+}

--- a/value.go
+++ b/value.go
@@ -1,0 +1,144 @@
+/*
+   Copyright 2020 Joseph Cumines
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package behaviortree
+
+import (
+	"errors"
+	"reflect"
+	"runtime"
+	"sync"
+)
+
+var (
+	runtimeCallers       = runtime.Callers
+	runtimeCallersFrames = runtime.CallersFrames
+	runtimeFuncForPC     = runtime.FuncForPC
+)
+
+var (
+	valueCallMutex  sync.Mutex
+	valueDataMutex  sync.RWMutex
+	valueDataKey    interface{}
+	valueDataChan   chan interface{}
+	valueDataCaller [1]uintptr
+)
+
+// WithValue will return the receiver wrapped with a key-value pair, using similar semantics to the context package.
+//
+// Values should only be used to attach information to BTs in a way that transits API boundaries, not for passing
+// optional parameters to functions. Some package-level synchronisation was necessary to facilitate this mechanism. As
+// such, this and the Node.Value method should be used with caution, preferably only outside normal operation.
+//
+// The same restrictions on the key apply as for context.WithValue.
+func (n Node) WithValue(key, value interface{}) Node {
+	if n == nil {
+		panic(errors.New(`behaviortree.Node.WithValue nil receiver`))
+	}
+	if key == nil {
+		panic(errors.New(`behaviortree.Node.WithValue nil key`))
+	}
+	if !reflect.TypeOf(key).Comparable() {
+		panic(errors.New(`behaviortree.Node.WithValue key is not comparable`))
+	}
+	return func() (Tick, []Node) {
+		n.valueHandle(func(k interface{}) (interface{}, bool) {
+			if k == key {
+				return value, true
+			}
+			return nil, false
+		})
+		return n()
+	}
+}
+
+// Value will return the value associated with this node for key, or nil if there is none.
+//
+// See also Node.WithValue, as well as the value mechanism provided by the context package.
+func (n Node) Value(key interface{}) interface{} {
+	if n != nil {
+		valueCallMutex.Lock()
+		defer valueCallMutex.Unlock()
+		return n.valueSync(key)
+	}
+	return nil
+}
+
+// valueSync is split out into it's own method and the Node.valuePrep call is used as a discriminator for relevant
+// values
+func (n Node) valueSync(key interface{}) (value interface{}) {
+	if n.valuePrep(key) {
+		select {
+		case value = <-valueDataChan:
+		default:
+		}
+		valueDataMutex.Lock()
+		valueDataKey = nil
+		valueDataChan = nil
+		valueDataMutex.Unlock()
+	}
+	return
+}
+
+func (n Node) valuePrep(key interface{}) bool {
+	valueDataMutex.Lock()
+	if runtimeCallers(2, valueDataCaller[:]) < 1 {
+		valueDataMutex.Unlock()
+		return false
+	}
+	valueDataKey = key
+	valueDataChan = make(chan interface{}, 1)
+	valueDataMutex.Unlock()
+	n()
+	return true
+}
+
+func (n Node) valueHandle(fn func(key interface{}) (interface{}, bool)) {
+	valueDataMutex.RLock()
+	dataKey, dataChan, dataCaller := valueDataKey, valueDataChan, valueDataCaller
+	valueDataMutex.RUnlock()
+
+	// fast exit case 1: there is no pending value operation
+	if dataChan == nil {
+		return
+	}
+
+	// fast exit case 2: pending value operation is not relevant
+	value, ok := fn(dataKey)
+	if !ok {
+		return
+	}
+	dataKey = nil
+
+	// slow case, may require walking the entire call stack
+	const depth = 2 << 7
+	callers := make([]uintptr, depth)
+	for skip := 4; skip > 0; skip += depth {
+		callers = callers[:runtimeCallers(skip, callers[:])]
+		for _, caller := range callers {
+			if caller == dataCaller[0] {
+				select {
+				case dataChan <- value:
+				default:
+				}
+				return
+			}
+		}
+		if len(callers) != depth {
+			return
+		}
+	}
+}

--- a/value_test.go
+++ b/value_test.go
@@ -1,0 +1,295 @@
+/*
+   Copyright 2020 Joseph Cumines
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package behaviortree
+
+import (
+	"fmt"
+	"runtime"
+	"testing"
+	"time"
+)
+
+func TestNode_Value_race(t *testing.T) {
+	defer func() func() {
+		start := runtime.NumGoroutine()
+		return func() {
+			time.Sleep(time.Millisecond * 100)
+			finish := runtime.NumGoroutine()
+			if start < finish {
+				t.Error(start, finish)
+			}
+		}
+	}()()
+	done := make(chan struct{})
+	defer close(done)
+	type k1 struct{}
+	type k2 struct{}
+	nodeOther := nn(Sequence).WithValue(k1{}, 5)
+	for i := 0; i < 3000; i++ {
+		node := nodeOther
+		nodeOther = func() (Tick, []Node) { return node() }
+		go func() {
+			ticker := time.NewTicker(time.Millisecond * 10)
+			defer ticker.Stop()
+			for {
+				node()
+				select {
+				case <-done:
+					return
+				case <-ticker.C:
+				}
+			}
+		}()
+	}
+	go func() {
+		ticker := time.NewTicker(time.Millisecond * 10)
+		defer ticker.Stop()
+		node := nn(Sequence).WithValue(k2{}, 3)
+		for {
+			node()
+			select {
+			case <-done:
+				return
+			case <-ticker.C:
+			}
+		}
+	}()
+	node := func() Node {
+		node := nn(Sequence).WithValue(k1{}, 6)
+		return func() (Tick, []Node) {
+			time.Sleep(time.Millisecond * 100)
+			return node()
+		}
+	}()
+	n := time.Now()
+	if v := node.Value(k1{}); v != 6 {
+		t.Error(v)
+	}
+	if v := node.Value(k2{}); v != nil {
+		t.Error(v)
+	}
+	t.Log(time.Now().Sub(n))
+}
+
+func nn(tick Tick, children ...Node) Node { return func() (Tick, []Node) { return tick, children } }
+
+//noinspection GoNilness
+func TestNode_Value_simple(t *testing.T) {
+	type k1 struct{}
+	type k2 struct{}
+	if v := (Node)(nil).Value(k1{}); v != nil {
+		t.Error(v)
+	}
+	if v := (Node)(nil).Value(k2{}); v != nil {
+		t.Error(v)
+	}
+	n1 := nn(Sequence)
+	if v := n1.Value(k1{}); v != nil {
+		t.Error(v)
+	}
+	if v := n1.Value(k2{}); v != nil {
+		t.Error(v)
+	}
+	n2 := n1.WithValue(k1{}, `v1`)
+	if v := n2.Value(k1{}); v != `v1` {
+		t.Error(v)
+	}
+	if frame, _ := runtime.CallersFrames(valueDataCaller[:]).Next(); frame.Function != `github.com/joeycumines/go-behaviortree.Node.valueSync` {
+		t.Error(frame)
+	}
+	if v := n2.Value(k2{}); v != nil {
+		t.Error(v)
+	}
+	n3 := n2.WithValue(k2{}, `v2`)
+	if v := n3.Value(k1{}); v != `v1` {
+		t.Error(v)
+	}
+	if v := n3.Value(k2{}); v != `v2` {
+		t.Error(v)
+	}
+	n4 := n3.WithValue(k1{}, `v3`)
+	if v := n4.Value(k1{}); v != `v3` {
+		t.Error(v)
+	}
+	if v := n4.Value(k2{}); v != `v2` {
+		t.Error(v)
+	}
+	if v := n3.Value(k1{}); v != `v1` {
+		t.Error(v)
+	}
+	if v := n3.Value(k2{}); v != `v2` {
+		t.Error(v)
+	}
+}
+
+func TestNode_Value_noCaller(t *testing.T) {
+	done := make(chan struct{})
+	defer func() func() {
+		old := runtimeCallers
+		runtimeCallers = func(skip int, pc []uintptr) int {
+			close(done)
+			return 0
+		}
+		return func() {
+			runtimeCallers = old
+		}
+	}()()
+	if v := nn(Sequence).Value(nil); v != nil {
+		t.Error(v)
+	}
+	select {
+	case <-done:
+	default:
+		t.Error(`expected done`)
+	}
+	valueDataMutex.Lock()
+	valueDataMutex.Unlock()
+}
+
+func TestNode_Value_nested(t *testing.T) {
+	type k1 struct{}
+	node := nn(Sequence).WithValue(k1{}, 5)
+	if v := node.Value(k1{}); v != 5 {
+		t.Fatal(v)
+	}
+	for i := 0; i < 3000; i++ {
+		old := node
+		node = func() (Tick, []Node) { return old() }
+		if v := node.Value(k1{}); v != 5 {
+			t.Fatal(i, v)
+		}
+	}
+}
+
+func TestNode_WithValue_panicNilReceiver(t *testing.T) {
+	defer func() {
+		if r := fmt.Sprint(recover()); r != `behaviortree.Node.WithValue nil receiver` {
+			t.Error(r)
+		}
+	}()
+	Node(nil).WithValue(1, 2)
+	t.Error(`expected panic`)
+}
+
+func TestNode_WithValue_panicNilKey(t *testing.T) {
+	defer func() {
+		if r := fmt.Sprint(recover()); r != `behaviortree.Node.WithValue nil key` {
+			t.Error(r)
+		}
+	}()
+	Node(func() (Tick, []Node) { return nil, nil }).WithValue(nil, 2)
+	t.Error(`expected panic`)
+}
+
+func TestNode_WithValue_panicNotComparible(t *testing.T) {
+	defer func() {
+		if r := fmt.Sprint(recover()); r != `behaviortree.Node.WithValue key is not comparable` {
+			t.Error(r)
+		}
+	}()
+	Node(func() (Tick, []Node) { return nil, nil }).WithValue([]int(nil), 2)
+	t.Error(`expected panic`)
+}
+
+var Result interface{}
+
+func benchTick(node Node) (status Status, err error) {
+	for {
+		status, err = node.Tick()
+		if err != nil {
+			return
+		}
+		if status == Failure {
+			return
+		}
+	}
+}
+
+func Benchmark_newExampleCounter_withValue(b *testing.B) {
+	var (
+		status Status
+		err    error
+	)
+	for i := 0; i < b.N; i++ {
+		status, err = benchTick(newExampleCounter())
+		if err != nil {
+			b.Fatal(err)
+		}
+	}
+	Result = status
+}
+
+func Benchmark_newExampleCounter_sansValue(b *testing.B) {
+	b.StopTimer()
+	defer func() func() {
+		old := factory
+		factory = func(tick Tick, children []Node) (node Node) {
+			return func() (Tick, []Node) {
+				return tick, children
+			}
+		}
+		return func() {
+			factory = old
+		}
+	}()()
+	b.StartTimer()
+	var (
+		status Status
+		err    error
+	)
+	for i := 0; i < b.N; i++ {
+		status, err = benchTick(newExampleCounter())
+		if err != nil {
+			b.Fatal(err)
+		}
+	}
+	Result = status
+}
+
+func Benchmark_newExampleCounter_withValueBackgroundStringer(b *testing.B) {
+	{
+		b.StopTimer()
+		node := newExampleCounter()
+		done := make(chan struct{})
+		defer close(done)
+		go func() {
+			ticker := time.NewTicker(time.Millisecond)
+			defer ticker.Stop()
+			for {
+				_ = node.String()
+				select {
+				case <-done:
+					return
+				case <-ticker.C:
+				}
+			}
+		}()
+		time.Sleep(time.Millisecond * 50)
+		b.StartTimer()
+	}
+	var (
+		status Status
+		err    error
+	)
+	for i := 0; i < b.N; i++ {
+		status, err = benchTick(newExampleCounter())
+		if err != nil {
+			b.Fatal(err)
+		}
+	}
+	Result = status
+}


### PR DESCRIPTION
These changes feel close to being done but I am going to let them... ferment... for a while, before I merge them.

The most questionable part is the mechanism to encapsulate `behaviortree.Node` instances with metadata values a-la `context.WithValue`. Other significant changes include capturing a frame for the immediate caller of `behaviortree.New` and `behaviortree.NewNode`, and the implementation of `fmt.Stringer` for nodes.

The value mechanism has been introduced as a way to actually access any node factory call frame. The current implementation requires the introduction of (fast, shared read) mutex locking using an internal package var for all nodes instanced via those factories. In the absence of any calls to the `behaviortree.Node.Value` /  `behaviortree.Node.Frame` methods the performance impact should be about as inconsequential as synchronisation can be. There are cases that are expected to have significant performance impact (value calls under heavy load / high concurrency / node expansions with very deep call stacks). If I do decide to merge these changes I will better quantify the impact beforehand, and write some more comprehensive documentation.