### PR TITLE
Add metadata value provider helpers

### DIFF
--- a/frame.go
+++ b/frame.go
@@ -71,6 +71,8 @@ func GetFrame(n Valuer) *Frame {
 
 // WithFrame returns the value attachable with the frame attached.
 //
+// If frame is nil, it attaches a nil value for the frame key.
+//
 // This helper facilitates interoperability with external implementations of the [ValueAttachable] interface.
 func WithFrame[T any](n ValueAttachable[T], frame *Frame) T {
 	if frame == nil {
@@ -83,6 +85,25 @@ func WithFrame[T any](n ValueAttachable[T], frame *Frame) T {
 // WithFrame returns a copy of the receiver, wrapped with the frame attached.
 func (n Node) WithFrame(frame *Frame) Node {
 	return WithFrame[Node](n, frame)
+}
+
+type frameValueProvider Frame
+
+func (p *frameValueProvider) Value(key any) (any, bool) {
+	if key == (vkFrame{}) {
+		if p == nil {
+			return nil, true
+		}
+		return (*Frame)(p), true
+	}
+	return nil, false
+}
+
+// UseFrame returns a [ValueProvider] that provides the given frame.
+//
+// If frame is nil, it provides an interface nil for the frame key.
+func UseFrame(frame *Frame) ValueProvider {
+	return (*frameValueProvider)(frame)
 }
 
 // Frame will return the call frame for the caller of New/NewNode, an approximation based on the receiver, or nil.

--- a/frame.go
+++ b/frame.go
@@ -94,7 +94,8 @@ func (p *frameValueProvider) Value(key any) (any, bool) {
 		if p == nil {
 			return nil, true
 		}
-		return (*Frame)(p), true
+		f := Frame(*p)
+		return &f, true
 	}
 	return nil, false
 }
@@ -103,7 +104,11 @@ func (p *frameValueProvider) Value(key any) (any, bool) {
 //
 // If frame is nil, it provides an interface nil for the frame key.
 func UseFrame(frame *Frame) ValueProvider {
-	return (*frameValueProvider)(frame)
+	if frame == nil {
+		return (*frameValueProvider)(nil)
+	}
+	f := *frame
+	return (*frameValueProvider)(&f)
 }
 
 // Frame will return the call frame for the caller of New/NewNode, an approximation based on the receiver, or nil.

--- a/frame_test.go
+++ b/frame_test.go
@@ -166,3 +166,68 @@ func TestTick_Frame(t *testing.T) {
 		})
 	}
 }
+
+func TestUseFrame(t *testing.T) {
+	f := &Frame{Function: "test_frame_func", Line: 123}
+
+	// 1. Direct Provider
+	p := UseFrame(f)
+	if v, ok := p.Value(vkFrame{}); !ok {
+		t.Error("UseFrame returned false for vkFrame")
+	} else {
+		got := v.(*Frame)
+		if got.Function != f.Function {
+			t.Errorf("got function %q; want %q", got.Function, f.Function)
+		}
+	}
+
+	// 2. Empty Frame
+	fEmpty := &Frame{}
+	pEmpty := UseFrame(fEmpty)
+	if v, ok := pEmpty.Value(vkFrame{}); !ok {
+		t.Error("UseFrame(empty) returned false")
+	} else {
+		got := v.(*Frame)
+		if got != fEmpty {
+			t.Errorf("UseFrame(empty) returned %p; want %p", got, fEmpty)
+		}
+	}
+
+	// 3. Nil Frame
+	pNil := UseFrame(nil)
+	if v, ok := pNil.Value(vkFrame{}); !ok {
+		t.Error("UseFrame(nil) should return true for vkFrame")
+	} else if v != nil {
+		t.Errorf("UseFrame(nil) should return nil value; got %v", v)
+	}
+
+	// 4. Integration
+	var node Node = func() (Tick, []Node) {
+		UseValueProvider(UseFrame(f))
+		return func(children []Node) (Status, error) { return Success, nil }, nil
+	}
+
+	// Use GetFrame to verify exact attached value
+	gotF := GetFrame(node)
+	if gotF == nil {
+		t.Fatal("GetFrame(node) returned nil")
+	}
+	if gotF.Function != "test_frame_func" {
+		t.Errorf("GetFrame(node).Function = %q", gotF.Function)
+	}
+
+	// 5. Integration with Nil
+	var nodeNil Node = func() (Tick, []Node) {
+		UseValueProvider(UseFrame(nil))
+		return func(children []Node) (Status, error) { return Success, nil }, nil
+	}
+
+	if gf := GetFrame(nodeNil); gf != nil {
+		t.Errorf("GetFrame(nodeNil) = %v; want nil", gf)
+	}
+
+	// 6. Unknown Key
+	if _, ok := p.Value("unknown_key"); ok {
+		t.Error("UseFrame returned true for unknown key")
+	}
+}

--- a/shuffle_test.go
+++ b/shuffle_test.go
@@ -127,3 +127,16 @@ func TestShuffle_nil(t *testing.T) {
 		t.Fatal(v)
 	}
 }
+
+func TestShuffle_defaultSource(t *testing.T) {
+	// Execute the tick to trigger the default source usage
+	tick := Shuffle(Sequence, nil)
+	if tick == nil {
+		t.Fatal("expected non-nil tick")
+	}
+	// We just need to call it to exercise the default source path
+	tick([]Node{
+		func() (Tick, []Node) { return func([]Node) (Status, error) { return Success, nil }, nil },
+		func() (Tick, []Node) { return func([]Node) (Status, error) { return Success, nil }, nil },
+	})
+}


### PR DESCRIPTION
Add `UseFrame`, `UseName`, and `UseStructure` functions which return `ValueProvider` implementations for their respective metadata types.

These helpers facilitate interoperability with the `UseValueProvider` mechanism, allowing nodes to expose metadata (like call frames, names, and logical structures) directly from their definition logic without requiring external wrapping.

Update `WithName` to explicitly clear the name value when an empty string is passed, aligning behavior with `UseName` and ensuring correct "zero" value semantics.